### PR TITLE
Show(not hide) genre section when adding video manually

### DIFF
--- a/grails-app/assets/javascripts/streama/templates/modal--movie.tpl.htm
+++ b/grails-app/assets/javascripts/streama/templates/modal--movie.tpl.htm
@@ -87,7 +87,8 @@
         </div>
       </div>
 
-      <div ng-hide="addManually">
+<!--  <div ng-hide="addManually">-->
+      <div>
         <div class="form-group">
           <div class="col-sm-12">
             <label>Genre</label>


### PR DESCRIPTION
Disabled the genre section hiding, allowing the user to pick genres when adding a movie manually